### PR TITLE
Update webpack-dev-middleware to version 1.6.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "piping": "0.3.0",
     "pre-commit": "1.1.2",
     "webpack": "1.12.14",
-    "webpack-dev-middleware": "1.5.1",
+    "webpack-dev-middleware": "1.6.0",
     "webpack-hot-middleware": "2.10.0"
   },
   "dependencies": {


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[webpack-dev-middleware](https://www.npmjs.com/package/webpack-dev-middleware) just published its new version 1.6.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of webpack-dev-middleware – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 11 commits .
- [`7bad026`](https://github.com/webpack/webpack-dev-middleware/commit/7bad02693cfacda82eb150aeb35df340fe43d364) `1.6.0`
- [`4af4834`](https://github.com/webpack/webpack-dev-middleware/commit/4af48340be2de21f1d94d2bdc41caf7b9ca5cf6e) `Merge pull request #78 from ijse/master`
- [`260cc70`](https://github.com/webpack/webpack-dev-middleware/commit/260cc709a0d873a8182653ea9a818b199fac827d) `Merge pull request #73 from mzgoddard/range-headers`
- [`322605c`](https://github.com/webpack/webpack-dev-middleware/commit/322605c364c83ac719fdc5b49ecae084c06f0b0f) `Merge pull request #70 from pyrotechnick/patch-1`
- [`b05cd04`](https://github.com/webpack/webpack-dev-middleware/commit/b05cd045d83123d410c54627dec937506b8013e3) `get filename from url path`
- [`80796b7`](https://github.com/webpack/webpack-dev-middleware/commit/80796b78ea34814cb538db70bd4286ca8120260b) `Support Range requests commonly used by media`
- [`4f55fa7`](https://github.com/webpack/webpack-dev-middleware/commit/4f55fa7cc1f21f85300f4ddfb782a64f89a1f882) `Merge pull request #72 from bluedaniel/master`
- [`513c050`](https://github.com/webpack/webpack-dev-middleware/commit/513c050c322765047c9526bba2017539a69debed) `waitUntilValid function using ready function`
- [`2e58fbb`](https://github.com/webpack/webpack-dev-middleware/commit/2e58fbbdef28fed223c77fa57554e32f8f0de64d) `Permit webpack@2 betas`
- [`4525806`](https://github.com/webpack/webpack-dev-middleware/commit/45258060702e5a58371f9c5af4bc1f9884f61e0e) `Merge pull request #62 from koteus/master`
- [`75fa787`](https://github.com/webpack/webpack-dev-middleware/commit/75fa78788e85707c1abdf063677f3559f75d652a) `Allow slash in filename regex`

See the [full diff](https://github.com/webpack/webpack-dev-middleware/compare/a9fc7f47ad5e1f8b8ea9df930dc69ffa7715beb9...7bad02693cfacda82eb150aeb35df340fe43d364).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
