### PR TITLE
Update babel-eslint to version 6.0.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "devDependencies": {
     "babel-core": "6.7.2",
-    "babel-eslint": "6.0.0-beta.6",
+    "babel-eslint": "6.0.0",
     "babel-loader": "6.2.4",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[babel-eslint](https://www.npmjs.com/package/babel-eslint) just published its new version 6.0.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of babel-eslint – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 1 commits .
- [`000f4b8`](https://github.com/babel/babel-eslint/commit/000f4b841efd2b586855a08c789bc93043c1317a) `6.0.0`

See the [full diff](https://github.com/babel/babel-eslint/compare/cdb5bb0c9d50709488605a4c6d09d0acf5adac23...000f4b841efd2b586855a08c789bc93043c1317a).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
