### PR TITLE
Update babel-eslint to version 6.0.2 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "devDependencies": {
     "babel-core": "6.7.2",
-    "babel-eslint": "6.0.0-beta.6",
+    "babel-eslint": "6.0.2",
     "babel-loader": "6.2.4",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[babel-eslint](https://www.npmjs.com/package/babel-eslint) just published its new version 6.0.2, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of babel-eslint – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 9 commits .
- [`27debee`](https://github.com/babel/babel-eslint/commit/27debee58f0395516c1f37a9ad5cf23c55cb2c51) `6.0.2`
- [`6512450`](https://github.com/babel/babel-eslint/commit/651245051f3410fb37634f86c124988a8d987720) `Merge pull request #285 from josh/revert-282-no-implicit-globals-regression`
- [`ac8f2f5`](https://github.com/babel/babel-eslint/commit/ac8f2f571c57bf23af4c36dee2a0b470bff1f53f) `Revert "Fix processing sourceType: script"`
- [`32b6723`](https://github.com/babel/babel-eslint/commit/32b67230d45471e31d0602c4dad6f8caf689c552) `Merge pull request #282 from josh/no-implicit-globals-regression`
- [`292bceb`](https://github.com/babel/babel-eslint/commit/292bceb605dd90fff75a7b3ec79e95cc353c1019) `Don't override sourceType`
- [`2666afe`](https://github.com/babel/babel-eslint/commit/2666afe32c895f64d2a614494bd21b429133e905) `Test no-implicit-globals regression`
- [`fc38797`](https://github.com/babel/babel-eslint/commit/fc387976de85855fd922aaff0b96d2dea3b1d04f) `Allow eslint config to be overridden by test cases`
- [`636850b`](https://github.com/babel/babel-eslint/commit/636850bea94e72783c587fd018e724362493a1c3) `update install instructions for eslint 1 and 2`
- [`000f4b8`](https://github.com/babel/babel-eslint/commit/000f4b841efd2b586855a08c789bc93043c1317a) `6.0.0`

See the [full diff](https://github.com/babel/babel-eslint/compare/cdb5bb0c9d50709488605a4c6d09d0acf5adac23...27debee58f0395516c1f37a9ad5cf23c55cb2c51).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
