### PR TITLE
Update babel-core to version 6.7.6 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint"
   ],
   "devDependencies": {
-    "babel-core": "6.7.2",
+    "babel-core": "6.7.6",
     "babel-eslint": "6.0.0-beta.6",
     "babel-loader": "6.2.4",
     "babel-polyfill": "6.7.4",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[babel-core](https://www.npmjs.com/package/babel-core) just published its new version 6.7.6, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of babel-core – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
