### PR TITLE
Update babel-eslint to version 6.0.3 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "ava": "0.14.0",
     "babel-core": "6.7.2",
-    "babel-eslint": "6.0.0-beta.6",
+    "babel-eslint": "6.0.3",
     "babel-loader": "6.2.4",
     "babel-plugin-syntax-async-functions": "6.5.0",
     "babel-plugin-transform-regenerator": "6.6.5",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[babel-eslint](https://www.npmjs.com/package/babel-eslint) just published its new version 6.0.3, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of babel-eslint – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
