### PR TITLE
Update babel-core to version 6.7.7 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "devDependencies": {
     "ava": "0.14.0",
-    "babel-core": "6.7.2",
+    "babel-core": "6.7.7",
     "babel-eslint": "6.0.0-beta.6",
     "babel-loader": "6.2.4",
     "babel-plugin-syntax-async-functions": "6.5.0",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[babel-core](https://www.npmjs.com/package/babel-core) just published its new version 6.7.7, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of babel-core – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
