### PR TITLE
Update babel-eslint to version 6.0.4 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "ava": "0.14.0",
     "babel-core": "6.7.2",
-    "babel-eslint": "6.0.0-beta.6",
+    "babel-eslint": "6.0.4",
     "babel-loader": "6.2.4",
     "babel-plugin-syntax-async-functions": "6.5.0",
     "babel-plugin-transform-regenerator": "6.6.5",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[babel-eslint](https://www.npmjs.com/package/babel-eslint) just published its new version 6.0.4, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of babel-eslint – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

[GitHub Release](https://github.com/babel/babel-eslint/releases/tag/v6.0.4)

<h2>Bug Fixes</h2>


<ul>
<li>Fix parent not being set for decorator nodes. (<a href="http://urls.greenkeeper.io/babel/babel-eslint/pull/296" class="issue-link js-issue-link" data-url="https://github.com/babel/babel-eslint/issues/296" data-id="149007002" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#296</a>) (Rafał Ruciński)</li>
<li>Ensure strictmode is enabled/disabled when changing sourceType (<a href="http://urls.greenkeeper.io/babel/babel-eslint/pull/302" class="issue-link js-issue-link" data-url="https://github.com/babel/babel-eslint/issues/302" data-id="150862215" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#302</a>) (Daniel Tschinder)</li>
<li>Fix escope to take sourceType and ecmaVersion from options (<a href="http://urls.greenkeeper.io/babel/babel-eslint/pull/288" class="issue-link js-issue-link" data-url="https://github.com/babel/babel-eslint/issues/288" data-id="145138779" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#288</a>) (Daniel Tschinder)</li>
</ul>


<h2>Internal/Chore</h2>


<ul>
<li>Update lodash and replace pick by pickBy (<a href="http://urls.greenkeeper.io/babel/babel-eslint/pull/301" class="issue-link js-issue-link" data-url="https://github.com/babel/babel-eslint/issues/301" data-id="150697301" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#301</a>) (Daniel Tschinder)</li>
<li>Declare eslint call more simply in the scripts. (<a href="http://urls.greenkeeper.io/babel/babel-eslint/pull/297" class="issue-link js-issue-link" data-url="https://github.com/babel/babel-eslint/issues/297" data-id="149221685" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#297</a>) (Rafał Ruciński)</li>
<li>Add root: true to eslint config. (<a href="http://urls.greenkeeper.io/babel/babel-eslint/pull/294" class="issue-link js-issue-link" data-url="https://github.com/babel/babel-eslint/issues/294" data-id="149005922" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#294</a>) (Rafał Ruciński)</li>
<li>Make npm scripts work on Windows too. (<a href="http://urls.greenkeeper.io/babel/babel-eslint/pull/295" class="issue-link js-issue-link" data-url="https://github.com/babel/babel-eslint/issues/295" data-id="149005946" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#295</a>) (Rafał Ruciński)</li>
</ul>

---

The new version differs by 17 commits .
- [`cff6d35`](https://github.com/babel/babel-eslint/commit/cff6d35b223ad51dafbaee8908f38b0d1eb3c563) `6.0.4`
- [`cae8b66`](https://github.com/babel/babel-eslint/commit/cae8b66b1649ab33bc24056cfdee54e93674cf56) `Fix parent not being set for decorator nodes. (#296)`
- [`d140a8c`](https://github.com/babel/babel-eslint/commit/d140a8c3f6ab64e04d55c5eab27d8c657ee01141) `Ensure strictmode is enabled/disabled when changing sourceType (#302)`
- [`4cfc1e2`](https://github.com/babel/babel-eslint/commit/4cfc1e21ee9a11625caa5da10a4332f065b92f82) `Update lodash and replace pick by pickBy (#301)`
- [`991ec90`](https://github.com/babel/babel-eslint/commit/991ec90290d4c62ab5bfdddada4aa9bbac625bd3) `Fix escope to take sourceType and ecmaVersion from options (#288)`
- [`68f1921`](https://github.com/babel/babel-eslint/commit/68f192138e07f61e1f35145129faede8050f5620) `Declare eslint call more simply in the scripts. (#297)`
- [`2192e16`](https://github.com/babel/babel-eslint/commit/2192e16398a12278a328792af4f61cab9455542e) `Add root: true to eslint config. (#294)`
- [`e232263`](https://github.com/babel/babel-eslint/commit/e232263c63f9d3a3509f55e8d849ebefd607959c) `Make npm scripts work on Windows too. (#295)`
- [`27debee`](https://github.com/babel/babel-eslint/commit/27debee58f0395516c1f37a9ad5cf23c55cb2c51) `6.0.2`
- [`6512450`](https://github.com/babel/babel-eslint/commit/651245051f3410fb37634f86c124988a8d987720) `Merge pull request #285 from josh/revert-282-no-implicit-globals-regression`
- [`ac8f2f5`](https://github.com/babel/babel-eslint/commit/ac8f2f571c57bf23af4c36dee2a0b470bff1f53f) `Revert "Fix processing sourceType: script"`
- [`32b6723`](https://github.com/babel/babel-eslint/commit/32b67230d45471e31d0602c4dad6f8caf689c552) `Merge pull request #282 from josh/no-implicit-globals-regression`
- [`292bceb`](https://github.com/babel/babel-eslint/commit/292bceb605dd90fff75a7b3ec79e95cc353c1019) `Don't override sourceType`
- [`2666afe`](https://github.com/babel/babel-eslint/commit/2666afe32c895f64d2a614494bd21b429133e905) `Test no-implicit-globals regression`
- [`fc38797`](https://github.com/babel/babel-eslint/commit/fc387976de85855fd922aaff0b96d2dea3b1d04f) `Allow eslint config to be overridden by test cases`

There are 17 commits in total. See the [full diff](https://github.com/babel/babel-eslint/compare/cdb5bb0c9d50709488605a4c6d09d0acf5adac23...cff6d35b223ad51dafbaee8908f38b0d1eb3c563).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
