### PR TITLE
Update piping to version 0.3.1 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint": "2.4.0",
     "eslint-plugin-react": "4.2.3",
     "fakeredis": "1.0.3",
-    "piping": "0.3.0",
+    "piping": "0.3.1",
     "pre-commit": "1.1.2",
     "rimraf": "2.5.2",
     "webpack": "1.12.14",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[piping](https://www.npmjs.com/package/piping) just published its new version 0.3.1, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of piping – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 4 commits .
- [`1455df8`](https://github.com/mdlawson/piping/commit/1455df8f537990404e8f38d3be64bed2635aa917) `0.3.1`
- [`14c680a`](https://github.com/mdlawson/piping/commit/14c680acbe8f75fcca2d489df67aa0246a9f479a) `Merge pull request #12 from mntnoe/sigterm-fix-2`
- [`e02a019`](https://github.com/mdlawson/piping/commit/e02a01949d2a073baa7d7dcd666154e5c572b550) `Fix respawning not sending SIGTERM signal, second attempt`
- [`8e3e3d6`](https://github.com/mdlawson/piping/commit/8e3e3d6d3938abb367df3400a31f656496b283ef) `Revert "Fix respawning not sending SIGTERM signal"`

See the [full diff](https://github.com/mdlawson/piping/compare/b9142fe37bdfb799eec7c8ed7c8d686ccd6f45a0...1455df8f537990404e8f38d3be64bed2635aa917).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
