### PR TITLE
Update babel-polyfill to version 6.8.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-loader": "6.2.4",
     "babel-plugin-syntax-async-functions": "6.5.0",
     "babel-plugin-transform-regenerator": "6.6.5",
-    "babel-polyfill": "6.7.4",
+    "babel-polyfill": "6.8.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-1": "6.5.0",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[babel-polyfill](https://www.npmjs.com/package/babel-polyfill) just published its new version 6.8.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of babel-polyfill – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
