### PR TITLE
Update babel-register to version 6.8.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-1": "6.5.0",
-    "babel-register": "6.7.2",
+    "babel-register": "6.8.0",
     "eslint": "2.4.0",
     "eslint-plugin-react": "4.2.3",
     "fakeredis": "1.0.3",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[babel-register](https://www.npmjs.com/package/babel-register) just published its new version 6.8.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of babel-register – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
