### PR TITLE
Update body-parser to version 1.15.1 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "axios": "0.11.0",
     "babel-eslint": "6.0.4",
     "babel-runtime": "6.6.1",
-    "body-parser": "1.15.0",
+    "body-parser": "1.15.1",
     "bookshelf": "0.9.4",
     "cas": "github:grahamb/node-cas",
     "connect-redis": "3.0.2",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[body-parser](https://www.npmjs.com/package/body-parser) just published its new version 1.15.1, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of body-parser – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 13 commits .
- [`e701380`](https://github.com/expressjs/body-parser/commit/e701380ab9b862bbf2223e4df4835a15e4e1ff66) `1.15.1`
- [`38448d7`](https://github.com/expressjs/body-parser/commit/38448d71df6f4353220d5d510f14a29fa623a8fc) `deps: bytes@2.3.0`
- [`1f1f5b1`](https://github.com/expressjs/body-parser/commit/1f1f5b121ec033bb526db5f444525093be39aa59) `build: istanbul@0.4.3`
- [`59b9e42`](https://github.com/expressjs/body-parser/commit/59b9e42745f9fba6dd5fa02701a943e2f9ff719b) `build: support Node.js 6.x`
- [`b620e81`](https://github.com/expressjs/body-parser/commit/b620e81c4b03b4bf1ef56f6d1f32532fe945435b) `tests: relax platform error message expectations`
- [`d0737aa`](https://github.com/expressjs/body-parser/commit/d0737aab2925df24f7a5949ae6290020d9a3e682) `docs: clean up formatting of example titles`
- [`808a5d1`](https://github.com/expressjs/body-parser/commit/808a5d176241aa4aa0cb2124c129bddd5850c08d) `build: Node.js@5.11`
- [`b8a4fa2`](https://github.com/expressjs/body-parser/commit/b8a4fa2e121ccdf4c68c8ec4aa0bd89ac14b8908) `build: cache node_modules on Travis CI`
- [`1d2622d`](https://github.com/expressjs/body-parser/commit/1d2622df3ac21e3d0a649a5a19acc1d5ca3d1d63) `build: Node.js@5.9`
- [`21b1164`](https://github.com/expressjs/body-parser/commit/21b1164b4a7af39e0605d7f1453a872283fce97b) `deps: type-is@~1.6.12`
- [`1a727d9`](https://github.com/expressjs/body-parser/commit/1a727d91a31e85add9f9c08363bfd4089edcb679) `deps: raw-body@~2.1.6`
- [`6cc7f23`](https://github.com/expressjs/body-parser/commit/6cc7f23f6ef2a27dea73e2f4dfbd7c904d08eba2) `build: Node.js@5.8`
- [`31ee72b`](https://github.com/expressjs/body-parser/commit/31ee72b24200acc66491c6c6e27dfa8601488097) `build: Node.js@4.4`

See the [full diff](https://github.com/expressjs/body-parser/compare/5b4fabe344e5b3df9e9157c7e9b9e6f5706b1cec...e701380ab9b862bbf2223e4df4835a15e4e1ff66).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
